### PR TITLE
Fix fee scheduler period frequency rounding

### DIFF
--- a/src/helpers/fee.ts
+++ b/src/helpers/fee.ts
@@ -323,7 +323,15 @@ export function getBaseFeeParams(
 
   const minBaseFeeNumerator = bpsToFeeNumerator(minBaseFeeBps);
 
-  const periodFrequency = new BN(totalDuration / numberOfPeriod);
+  let periodFrequency = new BN(totalDuration).divn(numberOfPeriod);
+
+  if (totalDuration % numberOfPeriod !== 0) {
+    periodFrequency = periodFrequency.addn(1);
+  }
+
+  if (periodFrequency.isZero()) {
+    periodFrequency = periodFrequency.addn(1);
+  }
 
   let reductionFactor: BN;
   if (feeSchedulerMode == FeeSchedulerMode.Linear) {

--- a/tests/feeHelpers.test.ts
+++ b/tests/feeHelpers.test.ts
@@ -96,4 +96,19 @@ describe("fee helpers function", () => {
     // less than 0.1%. Approximate by rounding
     expect(percentDifference < 0.1);
   });
+
+  it("rounds period frequency up when total duration is not evenly divisible", () => {
+    const maxBaseFee = 4000; // 40%
+    const minBaseFee = 100; // 1%
+
+    const baseFeeParams = getBaseFeeParams(
+      maxBaseFee,
+      minBaseFee,
+      FeeSchedulerMode.Linear,
+      3,
+      10
+    );
+
+    expect(baseFeeParams.periodFrequency.toNumber()).to.equal(4);
+  });
 });


### PR DESCRIPTION
## Summary
- correct fee scheduler period frequency calculation to avoid zero-length periods
- ensure uneven durations round up to the next whole slot and cover in unit test

## Testing
- npx ts-mocha -p ./tsconfig.json -t 1000000 tests/feeHelpers.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e516bcb9f0832e994f8bf4192bb0a0